### PR TITLE
Upgrade OpenJDK 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mvn -Dmaven.repo.local=/maven package
 COPY install_ddtrace.sh binaries/* /binaries/
 RUN /binaries/install_ddtrace.sh
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:11
 
 WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION


### PR DESCRIPTION
Previous image was deprecated, and I had JIT segfaults with it (unrelated to our product).